### PR TITLE
add support for pyqt 5.12 for us dual boot guys

### DIFF
--- a/widgetgallery.py
+++ b/widgetgallery.py
@@ -6,8 +6,9 @@ from PyQt5.QtWidgets import QApplication, QCheckBox, QComboBox , QDateTimeEdit, 
     QGroupBox, QDialog, QLabel, QLineEdit, QProgressBar, QPushButton, QRadioButton, QSlider, \
         QScrollBar, QSpinBox, QStyle, QStyleFactory, QTableWidget, \
         QTextEdit, QVBoxLayout, QHBoxLayout, QSizePolicy, QTabWidget, QWidget
-from PyQt5.QtCore import Qt, QEvent, QDateTime, QTimer
+from PyQt5.QtCore import Qt, QEvent, QDateTime, QTimer, QT_VERSION_STR
 from PyQt5.QtGui import QPalette
+
 
 class WidgetGallery(QDialog):
 
@@ -40,6 +41,10 @@ class WidgetGallery(QDialog):
         self.createBottomRightGroupBox()
         self.createProgressBar()
 
+        if (QT_VERSION_STR == '5.15.4'):
+            self.styleComboBox.textActivated.connect(self.changeStyle)
+        else:   #support pyqt 5.12
+            self.styleComboBox.activated[str].connect(self.changeStyle)
         self.styleComboBox.activated[str].connect(self.changeStyle)
         self.useStylePaletteCheckBox.toggled.connect(self.changePalette)
         self.disableWidgetsCheckBox.toggled.connect(self.topLeftGroupBox.setDisabled)

--- a/widgetgallery.py
+++ b/widgetgallery.py
@@ -1,12 +1,13 @@
 
+#include "widgetgallery.h"
+#include "norwegianwoodstyle.h"
+
 from PyQt5.QtWidgets import QApplication, QCheckBox, QComboBox , QDateTimeEdit, QDial, QGridLayout, \
     QGroupBox, QDialog, QLabel, QLineEdit, QProgressBar, QPushButton, QRadioButton, QSlider, \
         QScrollBar, QSpinBox, QStyle, QStyleFactory, QTableWidget, \
         QTextEdit, QVBoxLayout, QHBoxLayout, QSizePolicy, QTabWidget, QWidget
 from PyQt5.QtCore import Qt, QEvent, QDateTime, QTimer
 from PyQt5.QtGui import QPalette
-
-from norwegianwoodstyle import NorwegianWoodStyle
 
 class WidgetGallery(QDialog):
 
@@ -39,7 +40,7 @@ class WidgetGallery(QDialog):
         self.createBottomRightGroupBox()
         self.createProgressBar()
 
-        self.styleComboBox.textActivated.connect(self.changeStyle)
+        self.styleComboBox.activated[str].connect(self.changeStyle)
         self.useStylePaletteCheckBox.toggled.connect(self.changePalette)
         self.disableWidgetsCheckBox.toggled.connect(self.topLeftGroupBox.setDisabled)
         self.disableWidgetsCheckBox.toggled.connect(self.topRightGroupBox.setDisabled)
@@ -70,11 +71,12 @@ class WidgetGallery(QDialog):
         self.styleChanged()
  
     def changeStyle(self, styleName):
-        if (styleName == "NorwegianWood"):
-            QApplication.setStyle(NorwegianWoodStyle())
-        else:
-            QApplication.setStyle(QStyleFactory.create(styleName))
-        
+        #if (styleName == "NorwegianWood"):
+        #    QApplication.setStyle(NorwegianWoodStyle())
+        #else:
+        #    pass    
+        QApplication.setStyle(QStyleFactory.create(styleName))
+
 
     def changePalette(self):
         QApplication.setPalette(
@@ -95,6 +97,7 @@ class WidgetGallery(QDialog):
 
 
     def advanceProgressBar(self):
+
         curVal = self.progressBar.value()
         maxVal = self.progressBar.maximum()
         self.progressBar.setValue(curVal + (maxVal - curVal) / 100)

--- a/widgetgallery.py
+++ b/widgetgallery.py
@@ -45,7 +45,6 @@ class WidgetGallery(QDialog):
             self.styleComboBox.textActivated.connect(self.changeStyle)
         else:   #support pyqt 5.12
             self.styleComboBox.activated[str].connect(self.changeStyle)
-        self.styleComboBox.activated[str].connect(self.changeStyle)
         self.useStylePaletteCheckBox.toggled.connect(self.changePalette)
         self.disableWidgetsCheckBox.toggled.connect(self.topLeftGroupBox.setDisabled)
         self.disableWidgetsCheckBox.toggled.connect(self.topRightGroupBox.setDisabled)


### PR DESCRIPTION
Changed QComboBox::textActivated which is not supported my pyqt5.12 to QComboBox::activated[str] which is. Sadly there is not backwards compatibility here so added detection of qt version to select proper line of code. UNTESTED with qt5.15. 